### PR TITLE
Feat: [BE] 동화 상세정보 조회 API 구현

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,11 @@
 
 from typing import Union, Optional
-from fastapi import FastAPI, Depends, HTTPException
+from fastapi import FastAPI, Depends, HTTPException, Query
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from db import SessionLocal
-from db_models import Users, FairyTale
+from db_models import Users, FairyTale, FairyTaleLog
 from generate_summary import Summarizer
 from datetime import date, datetime, timedelta
 from passlib.context import CryptContext
@@ -80,6 +80,18 @@ class RecordCheckResponse(BaseModel):
     contents: str
     create_dates: date
     clips: int
+    
+class DetailRequest(BaseModel):
+    fid: str
+    uid: int
+    
+class DetailResponse(BaseModel):
+    uid: int
+    type: int
+    title: str
+    summary: str
+    contents: str
+    create_dates: date
 
 @app.post("/join", response_model=UserResponse)
 def join(req: UserRequest, db: Session = Depends(get_db)):
@@ -233,4 +245,29 @@ def check_records(
         contents=ft.contents,
         create_dates=ft.createDate,
         clips=log.clip,
+    )
+    
+# Backend API: 동화책 상세정보 조회
+@app.get("/users/{uid}/detail", response_model=DetailResponse)
+def book_detail(
+    uid: int,
+    fid: int = Query(..., description="동화 ID"),
+    db: Session = Depends(get_db)
+):
+    row = (
+        db.query(FairyTale)
+        .filter(FairyTale.uid == uid, FairyTale.fid == fid)
+        .first()
+    )
+
+    if not row:
+        raise HTTPException(status_code=404, detail="해당 동화를 찾을 수 없음")
+
+    return DetailResponse(
+        uid=row.uid,
+        type=row.type,
+        title=row.title,
+        summary=row.summary,
+        contents=row.contents,
+        create_dates=row.createDate,
     )


### PR DESCRIPTION
## 작업 내용

- 사용자 ID(uid)와 동화 ID(fid) 기반으로 특정 동화의 상세 정보를 조회하는 API 추가
- 조회된 동화의 제목, 요약, 본문, 생성일 등을 DetailResponse로 반환
- 해당 동화가 없을 경우 404 Not Found 예외 처리 적용
- 기존 나의 동화기록 내 SQL 연동 코드 관련 버그 수정 및 FastAPI 내 모듈(Query) 추가

## PR POINT

- 사용자별 동화 데이터 접근 제어 보장 (uid + fid 조건)
- 상세 조회 시 필요한 핵심 필드(title, summary, contents, createDate) 반환 구조 정리
- 예외 처리 로직 구현