### PR TITLE
Fix: 페이지별 오디오 생성

### DIFF
--- a/src/db/db_models.py
+++ b/src/db/db_models.py
@@ -21,6 +21,7 @@ class Users(Base):
     
     fairy_tales = relationship("FairyTale", back_populates="users")
     logs = relationship("FairyTaleLog", back_populates="users")
+    voices = relationship("Voices", back_populates="user")
 
 
 # FairyTale 테이블 정의
@@ -59,10 +60,9 @@ class Voices(Base):
     __tablename__ = "Voices"
     vid = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
     uid = Column(Integer, ForeignKey("Users.uid"), nullable=False)
-    contents = Column(Text, nullable=False)    
-    voiceFile = Column(String(256), nullable=False) 
+    voice_id = Column(String(50), nullable=False)     
+    memo = Column(String(10), nullable=False)         
+    voiceFile = Column(String(100), nullable=False)   
     createDate = Column(Date, nullable=False, default=date.today)
-
+    
     user = relationship("Users", back_populates="voices")
-
-Users.voices = relationship("Voices", back_populates="user", lazy="joined")  

--- a/src/generate_story/generate_sound.py
+++ b/src/generate_story/generate_sound.py
@@ -1,6 +1,7 @@
 from dotenv import load_dotenv
-import requests
 import os
+import requests
+from typing import Generator, Optional
 
 class SoundGenerator:
     def __init__(self):
@@ -9,12 +10,11 @@ class SoundGenerator:
         self.API_KEY = os.getenv("API_KEY")
         if not self.API_KEY:
             raise RuntimeError("API_KEY가 설정되지 않았습니다.")
+        self.ADD_URL = "https://api.elevenlabs.io/v1/voices/add"
+        self.TTS_BASE = "https://api.elevenlabs.io/v1/text-to-speech"
         
-    def register(self, audio_path, uid, url="https://api.elevenlabs.io/v1/voices/add"):
-        url = url
-        files = {
-            "files": open(audio_path, "rb"),
-        }
+    def register(self, audio_path, uid, url: Optional[str]=None) -> dict:
+        url = url or self.ADD_URL
         data = {
             "name": f"{uid} voice",
             "description": "동화책 TTS 커스텀 목소리",
@@ -23,47 +23,42 @@ class SoundGenerator:
             "xi-api-key": self.API_KEY
         }
         
-        response = requests.post(url, headers=headers, data=data, files=files)
+        with open(audio_path, "rb") as f:
+            files = {"files": (os.path.basename(audio_path), f, "audio/mpeg")}
+            response = requests.post(url, headers=headers, data=data, files=files, timeout=60)
+
+
         if response.status_code != 200:
             raise Exception(f"Voice register failed: {response.text}")
         
-        res_json = response.json()
-        voice_id = res_json.get("voice_id")
+        voice_id = (response.json() or {}).get("voice_id")
+        if not voice_id:
+            raise Exception("voice_id가 응답에 없습니다.")
         
         return {
           "uid": uid,
           "voice_id": voice_id
         }
         
-    def tts_generator(self, fid, uid, voice_id, contents):
-        url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
+    def tts_generator(self, voice_id: str, text: str) -> Generator[bytes, None, None]:
+        url = f"{self.TTS_BASE}/{voice_id}/stream"
         headers = {
           "xi-api-key": self.API_KEY,
           "Accept": "audio/mpeg",
           "Content-Type": "application/json"
         }
         
-        data = {
-            "text": contents,
+        payload = {
+            "text": text,
             "model_id": "eleven_multilingual_v2",
-            "voice_settings": {
-                "stability": 0.5,
-                "similarity_boost": 0.8
-            }
+            "voice_settings": {"stability": 0.5, "similarity_boost": 0.8},
         }
         
-        response = requests.post(url, headers=headers, json=data)
+        response = requests.post(url, headers=headers, json=payload, stream=True, timeout=None)
         
         if response.status_code != 200:
             raise Exception(f"TTS 생성이 실패하였습니다.: {response.text}")
         
-        output_path = f"output_{fid}.mp3"
-        with open(output_path, "wb") as f:
-            f.write(response.content)
-
-        return {
-          "fid": fid,
-          "uid": uid,
-          "contents": contents,
-          "output_path": output_path          
-        }
+        for chunk in response.iter_content(chunk_size=8192):
+            if chunk:
+                yield chunk

--- a/src/generate_story/generate_summary.py
+++ b/src/generate_story/generate_summary.py
@@ -4,7 +4,7 @@ from peft import PeftModel
 from datetime import date
 import torch
 import re
-
+from typing import List, Union
 
 class Summarizer:
     def __init__(self):
@@ -150,22 +150,12 @@ class Summarizer:
             "success": True,
         }
 
-    # 2문장 단위로 분할
-    def split_into_chunks(self, contents: str, sentences_per_chunk: int = 2) -> list[str]:
-        sentences = re.split(r'(?<=[.!?])\s+', contents.strip())
-        chunks = []
-        for i in range(0, len(sentences), sentences_per_chunk):
-            chunk = " ".join(sentences[i:i+sentences_per_chunk])
-            if chunk:
-                chunks.append(chunk)
-        return chunks
-
     # 페이지별 요약
-    def generate_page_summaries(self, contents: str, max_new_tokens: int = 77) -> list[str]:
+    def generate_page_summaries(self, contents: List[str], max_new_tokens: int = 77) -> list[str]:
         if self.model is None or self.tokenizer is None:
             raise RuntimeError("모델이 로드되지 않았습니다. load_lora_model()을 먼저 호출하세요.")
 
-        chunks = self.split_into_chunks(contents, sentences_per_chunk=2)
+        chunks = contents
         results = []
 
         for i, chunk in enumerate(chunks):


### PR DESCRIPTION
## 작업한 내용
- 생성된 동화 텍스트 페이지 단위로 분할
- 각 페이지 ElevenLabs TTS 스트리밍으로 재생
- 사용자 업로드 음성을 ElevenLabs에 등록해 받은 voice_id를 페이지별 TTS에 해당 voice_id 사용

## PR POINT
### 페이지별 오디오 스트리밍API: /tts/stream_page
- 입력: voice_id, pages: List[str], page: int
- 출력: StreamingResponse(audio/mpeg) 

 사용자 음성 등록 API: /voices/register
- 업로드 받은 audio를 ElevenLabs voices/add로 전송
- 응답의 voice_id를 **Voices(uid ↔ voice_id)**로 저장

## 관련 이슈
- Resolved: 
#22 