### PR TITLE
Feat: story_reading

### DIFF
--- a/src/generate_story/story_reading.py
+++ b/src/generate_story/story_reading.py
@@ -1,0 +1,140 @@
+# story_reading.py
+from __future__ import annotations
+from typing import List, Optional, Dict, Any, Union
+from datetime import date
+import json
+
+from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+
+from db.db_models import FairyTale, FairyTaleLog, Voices
+from generate_story.generate_sound import SoundGenerator
+
+
+def _as_pages(contents: Union[List[str], str, None]) -> List[str]:
+    if contents is None:
+        return []
+    if isinstance(contents, list):
+        return [p.strip() for p in contents if (p or "").strip()]
+    # TEXT에 JSON 배열 문자열로 저장된 경우
+    text = contents.strip()
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, list):
+            return [str(p).strip() for p in parsed if str(p).strip()]
+    except Exception:
+        pass
+    return []
+
+
+class StoryReader:
+    """
+    동화 읽기 서비스 (페이지가 이미 List[str]로 나눠져 있는 전제)
+    - 이어듣기 상태(resume): FairyTaleLog.clip = 마지막 읽은 페이지
+    - 페이지 읽기(stream): SoundGenerator를 통해 실시간 스트리밍 + clip 갱신
+    """
+    def __init__(self):
+        self.sg = SoundGenerator()
+
+    # 이어듣기 상태 조회
+    def resume_reading(self, db: Session, uid: int, fid: int) -> Dict[str, Any]:
+        ft = self._get_fairy_tale_or_404(db, uid, fid)
+        pages = _as_pages(ft.contents)
+        total_pages = len(pages)
+
+        log = (
+            db.query(FairyTaleLog)
+            .filter(FairyTaleLog.uid == uid, FairyTaleLog.fid == fid)
+            .order_by(FairyTaleLog.updateDate.desc(), FairyTaleLog.lid.desc())
+            .first()
+        )
+        last_page = int(getattr(log, "clip", 0) or 0) if log else 0  # clip=책갈피
+        next_page = min(last_page + 1, total_pages) if total_pages > 0 else 0
+
+        return {
+            "uid": uid,
+            "fid": fid,
+            "total_pages": total_pages,
+            "last_page": last_page,
+            "next_page": next_page,
+        }
+
+    # 특정 페이지 읽기
+    def stream_page(
+        self,
+        db: Session,
+        uid: int,
+        fid: int,
+        page: int,
+        voice_id: Optional[str] = None,
+    ) -> StreamingResponse:
+        ft = self._get_fairy_tale_or_404(db, uid, fid)
+        pages = _as_pages(ft.contents)
+        if not pages:
+            raise HTTPException(status_code=400, detail="동화에 페이지가 없습니다. (pages 비어있음)")
+
+        if page < 1 or page > len(pages):
+            raise HTTPException(status_code=400, detail=f"잘못된 페이지 번호: 1~{len(pages)}")
+
+        text = (pages[page - 1] or "").strip()
+        if not text:
+            raise HTTPException(status_code=400, detail="선택한 페이지 내용이 비어있습니다.")
+
+        vid = voice_id or self._get_user_default_voice_id(db, uid)
+        if not vid:
+            raise HTTPException(status_code=400, detail="voice_id 없음. 먼저 /voices/register를 호출하세요.")
+
+        # clip
+        log = (
+            db.query(FairyTaleLog)
+            .filter(FairyTaleLog.uid == uid, FairyTaleLog.fid == fid)
+            .order_by(FairyTaleLog.updateDate.desc(), FairyTaleLog.lid.desc())
+            .first()
+        )
+        try:
+            if not log:
+                log = FairyTaleLog(
+                    uid=uid, fid=fid, clip=page,
+                    createDate=date.today(), updateDate=date.today()
+                )
+                db.add(log); db.flush(); db.refresh(log)
+            else:
+                log.clip = max(int(getattr(log, "clip", 0) or 0), page)
+                log.updateDate = date.today()
+            db.commit()
+        except Exception as e:
+            db.rollback()
+            raise HTTPException(status_code=500, detail=f"log_update_failed: {e}")
+
+        # ElevenLabs TTS 실시간 스트리밍
+        return StreamingResponse(
+            self.sg.tts_generator(voice_id=vid, text=text),
+            media_type="audio/mpeg",
+            headers={
+                "Content-Disposition": f'inline; filename="fid{fid}_page{page}.mp3"',
+                "X-Total-Pages": str(len(pages)),
+                "X-Current-Page": str(page),
+            },
+        )
+
+    def _get_user_default_voice_id(self, db: Session, uid: int) -> Optional[str]:
+        v = (
+            db.query(Voices)
+            .filter(Voices.uid == uid)
+            .order_by(Voices.createDate.desc())
+            .first()
+        )
+        return getattr(v, "voice_id", None) if v else None
+
+    def _get_fairy_tale_or_404(self, db: Session, uid: int, fid: int) -> FairyTale:
+        ft = (
+            db.query(FairyTale)
+            .filter(FairyTale.uid == uid, FairyTale.fid == fid)
+            .first()
+        )
+        if not ft:
+            raise HTTPException(status_code=404, detail="해당 동화를 찾을 수 없습니다.")
+        return ft

--- a/src/generate_story/story_reading.py
+++ b/src/generate_story/story_reading.py
@@ -1,16 +1,12 @@
-# story_reading.py
 from __future__ import annotations
 from typing import List, Optional, Dict, Any, Union
 from datetime import date
 import json
-
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
-
 from db.db_models import FairyTale, FairyTaleLog, Voices
 from generate_story.generate_sound import SoundGenerator
-
 
 def _as_pages(contents: Union[List[str], str, None]) -> List[str]:
     if contents is None:
@@ -31,11 +27,7 @@ def _as_pages(contents: Union[List[str], str, None]) -> List[str]:
 
 
 class StoryReader:
-    """
-    동화 읽기 서비스 (페이지가 이미 List[str]로 나눠져 있는 전제)
-    - 이어듣기 상태(resume): FairyTaleLog.clip = 마지막 읽은 페이지
-    - 페이지 읽기(stream): SoundGenerator를 통해 실시간 스트리밍 + clip 갱신
-    """
+
     def __init__(self):
         self.sg = SoundGenerator()
 


### PR DESCRIPTION
## 작업한 내용
### StoryReader 클래스 구현
- 동화책 페이지 분리 로직 추가
- 이어듣기 상태 조회(resume_reading) 기능 구현 → last_page, next_page 계산
- 특정 페이지 읽기(stream_page) 기능 구현 → ElevenLabs TTS 실시간 스트리밍
- 사용자 기본 보이스(Voices.voice_id) 자동 선택 및 clip(책갈피) 업데이트 로직 추가

## PR POINT
- 페이지 분리 로직이 다양한 입력(List/JSON/빈 값)을 안전하게 처리하는지 검증 필요
- voice_id 미지정 시 최신 1건을 사용하는 기본 보이스 선택 로직이 적절한지 리뷰 필요

## 관련 이슈
- Resolved: 
#29 